### PR TITLE
Allow to pass ArrayView instead of Array

### DIFF
--- a/benches/cpa.rs
+++ b/benches/cpa.rs
@@ -17,8 +17,8 @@ fn cpa_sequential(leakages: &Array2<f64>, plaintexts: &Array2<u8>) -> Cpa {
 
     for i in 0..leakages.shape()[0] {
         cpa.update(
-            leakages.row(i).map(|&x| x as usize),
-            plaintexts.row(i).map(|&y| y as usize),
+            leakages.row(i).map(|&x| x as usize).view(),
+            plaintexts.row(i).map(|&y| y as usize).view(),
         );
     }
 
@@ -40,10 +40,7 @@ fn cpa_normal_sequential(leakages: &Array2<f64>, plaintexts: &Array2<u8>) -> cpa
         leakages.axis_chunks_iter(Axis(0), chunk_size),
         plaintexts.axis_chunks_iter(Axis(0), chunk_size),
     ) {
-        cpa.update(
-            leakages_chunk.map(|&x| x as f32),
-            plaintexts_chunk.to_owned(),
-        );
+        cpa.update(leakages_chunk.map(|&x| x as f32).view(), plaintexts_chunk);
     }
 
     cpa.finalize();
@@ -78,8 +75,8 @@ fn bench_cpa(c: &mut Criterion) {
             |b, (leakages, plaintexts)| {
                 b.iter(|| {
                     cpa::cpa(
-                        &leakages.map(|&x| x as usize),
-                        &plaintexts.map(|&x| x as usize),
+                        leakages.map(|&x| x as usize).view(),
+                        plaintexts.map(|&x| x as usize).view(),
                         256,
                         0,
                         leakage_model,
@@ -102,8 +99,8 @@ fn bench_cpa(c: &mut Criterion) {
             |b, (leakages, plaintexts)| {
                 b.iter(|| {
                     cpa_normal::cpa(
-                        &leakages.map(|&x| x as f32),
-                        plaintexts,
+                        leakages.map(|&x| x as f32).view(),
+                        plaintexts.view(),
                         256,
                         leakage_model_normal,
                         500,

--- a/benches/snr.rs
+++ b/benches/snr.rs
@@ -9,14 +9,14 @@ fn snr_sequential(leakages: &Array2<i64>, plaintexts: &Array2<u8>) -> Array1<f64
     let mut snr = Snr::new(leakages.shape()[1], 256);
 
     for i in 0..leakages.shape()[0] {
-        snr.process(&leakages.row(i), plaintexts.row(i)[0] as usize);
+        snr.process(leakages.row(i), plaintexts.row(i)[0] as usize);
     }
 
     snr.snr()
 }
 
 fn snr_parallel(leakages: &Array2<i64>, plaintexts: &Array2<u8>) -> Array1<f64> {
-    compute_snr(leakages, 256, |i| plaintexts.row(i)[0].into(), 500)
+    compute_snr(leakages.view(), 256, |i| plaintexts.row(i)[0].into(), 500)
 }
 
 fn bench_snr(c: &mut Criterion) {

--- a/examples/cpa_partioned.rs
+++ b/examples/cpa_partioned.rs
@@ -22,7 +22,7 @@ fn cpa() -> Result<()> {
     let folder = String::from("../../data"); // Directory of leakages and metadata
     let nfiles = 5; // Number of files in the directory. TBD: Automating this value
 
-    /* Parallel operation using multi-threading on patches */
+    /* Parallel operation using multi-threading on batches */
     let mut cpa = (0..nfiles)
         .progress_with(progress_bar(nfiles))
         .map(|n| {
@@ -33,13 +33,13 @@ fn cpa() -> Result<()> {
             (leakages, plaintext)
         })
         .par_bridge()
-        .map(|patch| {
+        .map(|batch| {
             let mut c = Cpa::new(size, guess_range, target_byte, leakage_model);
-            let len_leakage = patch.0.shape()[0];
+            let len_leakage = batch.0.shape()[0];
             for i in 0..len_leakage {
                 c.update(
-                    patch.0.row(i).map(|x| *x as usize),
-                    patch.1.row(i).map(|y| *y as usize),
+                    batch.0.row(i).map(|x| *x as usize).view(),
+                    batch.1.row(i).map(|y| *y as usize).view(),
                 );
             }
             c

--- a/examples/rank.rs
+++ b/examples/rank.rs
@@ -41,8 +41,8 @@ fn rank() -> Result<()> {
                     || Cpa::new(size, guess_range, target_byte, leakage_model),
                     |mut r: Cpa, n| {
                         r.update(
-                            l_sample.row(n).map(|l: &FormatTraces| *l as usize),
-                            p_sample.row(n).map(|p: &FormatMetadata| *p as usize),
+                            l_sample.row(n).map(|l| *l as usize).view(),
+                            p_sample.row(n).map(|p| *p as usize).view(),
                         );
                         r
                     },

--- a/examples/snr.rs
+++ b/examples/snr.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
                 for trace in batch {
                     // `process` takes an `ArrayView1` argument, which makes possible to pass a
                     // trace slice: `traces.leakage.slice(s![100..])` for instance.
-                    snr.process(&trace.leakage.view(), trace.value as usize)
+                    snr.process(trace.leakage.view(), trace.value as usize)
                 }
                 snr
             },


### PR DESCRIPTION
`ArrayView` is more flexible than `&Array` as it can represent a view of a part of the array.